### PR TITLE
romdisk: fix load command parameter length

### DIFF
--- a/romdisk/uart.asm
+++ b/romdisk/uart.asm
@@ -79,6 +79,8 @@ _load_code_rom:
         ld sp, 0xffff
         ; Jump to the user program (0x4000) in case of no error
         ex de, hl
+        ; We aren't supplying a parameter string in de, so set length to zero
+        ld bc,0 ;
         jp (hl)
 _load_read_error:
         push hl


### PR DESCRIPTION
The 'load' command doesn't supply a parameter string to the code that it is launching, but doesn't clear de or bc. So launched programs that are expecting a parameter interpret rubbish where de points. Setting the parameter to empty by zeroing bc means that programs expecting a parameter can notice and die nicely when run in the 'load' context.