### PR TITLE
video: make video write report bytes written

### DIFF
--- a/target/zeal8bit/video.asm
+++ b/target/zeal8bit/video.asm
@@ -337,7 +337,11 @@ video_write:
     ; Page 3 is kernel RAM
     ; We don't need to use page1 for VRAM since we will use I/O bus, map it and print the buffer
     MAP_TEXT_CTRL()
-    jp print_buffer
+    ; Write should always be full-length, so BC is unchanged
+    push bc
+    call print_buffer
+    pop bc
+    ret
 
 
     ; Read not supported yet.


### PR DESCRIPTION
I noticed that the write() call to the video device wasn't returning the number of bytes written on success; it always updated BC (or length pointer param in C) with zero. 

This commit sandwiches the print_buffer call between push / pop to retain length. It assumes that the write will always be full-length successful, which seems to be the case.