### PR TITLE
MacOS Build Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
 # Set the binaries
 SHELL := /bin/bash
+
+ifeq '$(findstring ;,$(PATH))' ';'
+    detected_OS := Windows
+else
+    detected_OS := $(shell uname 2>/dev/null || echo Unknown)
+    detected_OS := $(patsubst CYGWIN%,Cygwin,$(detected_OS))
+    detected_OS := $(patsubst MSYS%,MSYS,$(detected_OS))
+    detected_OS := $(patsubst MINGW%,MSYS,$(detected_OS))
+endif
+
 # If z88dk has been install through snap, the binary may be prefixed with "z88dk"
 # So choose any of z88dk-* or z88dk.z88dk-*, as long as one exists
 CC=$(shell which z88dk-z80asm z88dk.z88dk-z80asm | head -1)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ At the moment, the project has only been assembled on Linux (Ubuntu 20.04 and 22
 
 * bash
 * git (to clone this repo)
-* make
+* make (GNU Make 4+)
 * python3 with pip3. Used for the `menuconfig`.
 * z88dk v2.2 (or later). Only its assembler, `z80asm`, is strictly required. The latest version of `z80asm` must be used as earlier versions don't have support for `MACRO`.
 
@@ -111,7 +111,18 @@ sudo apt install git python3 python3-pip
 pip3 install --ignore-installed --user kconfiglib
 ```
 
+On MacOS, the following commands can be used to install the dependencies.
+```
+brew install make
+brew install binutils
+```
+
 For installing Z88DK, please [check out their Github project](https://github.com/z88dk/z88dk).
+
+### Darwin / MacOS Requirements
+
+> [!IMPORTANT]
+> Use `gmake` instead of `make` whenever instructed to use `make` throughout.
 
 ## Configuring Zeal 8-bit OS
 

--- a/kernel_headers/examples/sdcc/Makefile
+++ b/kernel_headers/examples/sdcc/Makefile
@@ -1,5 +1,22 @@
 SHELL := /bin/bash
 
+ifeq '$(findstring ;,$(PATH))' ';'
+    detected_OS := Windows
+else
+    detected_OS := $(shell uname 2>/dev/null || echo Unknown)
+    detected_OS := $(patsubst CYGWIN%,Cygwin,$(detected_OS))
+    detected_OS := $(patsubst MSYS%,MSYS,$(detected_OS))
+    detected_OS := $(patsubst MINGW%,MSYS,$(detected_OS))
+endif
+
+STAT_BYTES = stat
+ifeq ($(detected_OS),Darwin)
+	STAT_BYTES += -f %z
+# TODO: Support Windows?
+else
+	STAT_BYTES += -c %s
+endif
+
 # Specify the files to compile and the name of the final binary
 SRCS=main.c str.c
 BIN=example.bin
@@ -28,6 +45,9 @@ LD=sdldz80
 LDFLAGS=-n -mjwx -i -b _HEADER=0x4000 $(SDLD_FLAGS) -k $(ZOS_PATH)/kernel_headers/sdcc/lib -l z80
 # Binary used to convert ihex to binary
 OBJCOPY=objcopy
+ifeq ($(detected_OS),Darwin)
+	OBJCOPY=gobjcopy
+endif
 
 # Generate the intermediate Intel Hex binary name
 BIN_HEX=$(patsubst %.bin,%.ihx,$(BIN))
@@ -40,6 +60,7 @@ SRCS_REL=$(patsubst %.c,%.rel,$(SRCS_OUT_DIR))
 
 all: clean $(OUTPUT_DIR) $(OUTPUT_DIR)/$(BIN_HEX) $(OUTPUT_DIR)/$(BIN)
 	@bash -c 'echo -e "\x1b[32;1mSuccess, binary generated: $(OUTPUT_DIR)/$(BIN)\x1b[0m"'
+	@echo "uartrcv $$($(STAT_BYTES) $(OUTPUT_DIR)/$(BIN)) $(BIN)"
 
 $(OUTPUT_DIR):
 	mkdir -p $(OUTPUT_DIR)


### PR DESCRIPTION
* add `detected_OS` in Makefile
* add Darwin support for `stat`

Requires `brew install make` (ie; GNU Make v4+, MacOS ships with GNU Make 3)
Use `gmake` in place of `make` on MacOS