### PR TITLE
Updated base_sdcc.mk

### DIFF
--- a/kernel_headers/sdcc/base_sdcc.mk
+++ b/kernel_headers/sdcc/base_sdcc.mk
@@ -54,7 +54,7 @@ SRCS_REL=$(patsubst %.c,%.rel,$(SRCS_OUT_DIR))
 
 .PHONY: all clean
 
-all: clean $(OUTPUT_DIR) $(OUTPUT_DIR)/$(BIN_HEX) $(OUTPUT_DIR)/$(BIN)
+all:: clean $(OUTPUT_DIR) $(OUTPUT_DIR)/$(BIN_HEX) $(OUTPUT_DIR)/$(BIN)
 	@bash -c 'echo -e "\x1b[32;1mSuccess, binary generated: $(OUTPUT_DIR)/$(BIN)\x1b[0m"'
 
 $(OUTPUT_DIR):


### PR DESCRIPTION
* use the [double colon](https://www.gnu.org/software/make/manual/html_node/Double_002dColon.html) syntax for the Makefile `all` rule, to allowing overriding it