### PR TITLE
strutils.lib - update strlen to not destroy A register

### DIFF
--- a/kernel_headers/z88dk-z80asm/include/strutils_h.asm
+++ b/kernel_headers/z88dk-z80asm/include/strutils_h.asm
@@ -179,8 +179,9 @@
     EXTERN parse_hex_digit
 
 
-    ; Parse string into a 16-bit integer. Hexadecimal string can start with
-    ; 0x or $, decimal number start with any valid digit.
+    ; Parse string into a 16-bit integer.
+    ; Hexadecimal string can start with  0x or $
+    ; Decimal number can start with any valid digit
     ; Parameters:
     ;       HL - String to parse
     ; Returns:
@@ -193,8 +194,8 @@
     EXTERN parse_int
 
 
-    ; Parse a hexadecimal string into a 16-bit integer. The value must not have
-    ; any prefix.
+    ; Parse a hexadecimal string into a 16-bit integer.
+    ; The value must not have any prefix.
     ; Parameters:
     ;       HL - String to parse
     ; Returns:

--- a/kernel_headers/z88dk-z80asm/src/strutils/strlen.asm
+++ b/kernel_headers/z88dk-z80asm/src/strutils/strlen.asm
@@ -10,9 +10,10 @@
     ; Returns:
     ;   BC - Length of the string
     ; Alters:
-    ;   A, BC
+    ;   BC
     PUBLIC strlen
 strlen:
+    push af
     push hl
     xor a
     ld b, a
@@ -25,4 +26,5 @@ _strlen_loop:
     jr _strlen_loop
 _strlen_end:
     pop hl
+    pop af
     ret


### PR DESCRIPTION
* don't destroy AF when calling strlen (allows strsep and others to call strlen to set BC)
* format strutils_h doc comments