### PR TITLE
Align to new drivers hook option

### DIFF
--- a/target/agon/Kconfig
+++ b/target/agon/Kconfig
@@ -9,4 +9,8 @@ menu "Agon Light Configuration"
         bool
         default n
 
+    config TARGET_HAS_DRIVERS_HOOK
+        bool
+        default y
+
 endmenu

--- a/target/agon/pio.asm
+++ b/target/agon/pio.asm
@@ -42,7 +42,11 @@ interrupt_default_handler:
         ei
         reti
 
-
+        ; Routine called after all drivers have been initialized
+        PUBLIC target_drivers_hook
+target_drivers_hook:
+        INTERRUPTS_ENABLE()
+        ret
 
         ; No exit action at this point. Consider undoing the interrupt changes from boot?
 pio_deinit:

--- a/target/agon/romdisk.asm
+++ b/target/agon/romdisk.asm
@@ -23,10 +23,6 @@ romdisk_init:
         ; A has the status, return it if error
 
         or a
-
-        ; This is the last driver, enable interrupts here
-        INTERRUPTS_ENABLE()
-
         ret nz
         ; Else, return ERR_DRIVER_HIDDEN as we don't want this driver to be
         ; directly used by users.


### PR DESCRIPTION
Align the source code to compile using default setting for new target_drivers_hook. This makes more sense as the hook should be independent of any specific driver order.